### PR TITLE
correctly include parent fields

### DIFF
--- a/src/seaq/Queries/AdvancedQueryCriteria.cs
+++ b/src/seaq/Queries/AdvancedQueryCriteria.cs
@@ -125,7 +125,11 @@ namespace seaq
             if (_returnFields?.Any() is true)
                 return;
 
-            var flat = indices.SelectMany(x => x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true)).SelectMany(x => x.Fields);
+            var flat = indices
+                .SelectMany(x =>
+                    x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true))
+                .SelectMany(x =>
+                    new[] { x }.Concat(x.Fields));
 
             _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
         }
@@ -293,7 +297,11 @@ namespace seaq
             if (_returnFields?.Any() is true)
                 return;
 
-            var flat = indices.SelectMany(x => x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true)).SelectMany(x => x.Fields);
+            var flat = indices
+                .SelectMany(x => 
+                    x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true))
+                .SelectMany(x => 
+                    new[] { x }.Concat(x.Fields));
 
             _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
         }

--- a/src/seaq/Queries/SimpleQueryCriteria.cs
+++ b/src/seaq/Queries/SimpleQueryCriteria.cs
@@ -125,7 +125,11 @@ namespace seaq
             if (_returnFields?.Any() is true)
                 return;
 
-            var flat = indices.SelectMany(x => x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true)).SelectMany(x => x.Fields);
+            var flat = indices
+                .SelectMany(x =>
+                    x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true))
+                .SelectMany(x =>
+                    new[] { x }.Concat(x.Fields));
 
             _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
         }
@@ -299,7 +303,11 @@ namespace seaq
             if (_returnFields?.Any() is true)
                 return;
 
-            var flat = indices.SelectMany(x => x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true)).SelectMany(x => x.Fields);
+            var flat = indices
+                .SelectMany(x =>
+                    x.Fields.Where(x => x.IsIncludedField is true || x.HasIncludedField is true))
+                .SelectMany(x =>
+                    new[] { x }.Concat(x.Fields));
 
             _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
         }


### PR DESCRIPTION
had been ignoring root-level fields.  smooth move.

This fixes that.