### PR TITLE
should include child fields of configured incldued fields

### DIFF
--- a/src/seaq/Queries/AdvancedQueryCriteria.cs
+++ b/src/seaq/Queries/AdvancedQueryCriteria.cs
@@ -171,7 +171,11 @@ namespace seaq
                 .SelectMany(x =>
                     new[] { x }.Concat(x.Fields));
 
-            _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
+            _returnFields = flat
+                .Where(x => x.IsIncludedField is true)
+                .SelectMany(x =>
+                    x.FieldTree?
+                        .Select(z => new DefaultReturnField(z)));
         }
         internal void ApplyDefaultBuckets(Cluster cluster)
         {
@@ -390,7 +394,11 @@ namespace seaq
                 .SelectMany(x => 
                     new[] { x }.Concat(x.Fields));
 
-            _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
+            _returnFields = flat
+                .Where(x => x.IsIncludedField is true)
+                .SelectMany(x => 
+                    x.FieldTree?
+                        .Select(z => new DefaultReturnField(z)));
         }
         internal void ApplyDefaultBuckets(Cluster cluster)
         {

--- a/src/seaq/Queries/SimpleQueryCriteria.cs
+++ b/src/seaq/Queries/SimpleQueryCriteria.cs
@@ -164,7 +164,11 @@ namespace seaq
                 .SelectMany(x =>
                     new[] { x }.Concat(x.Fields));
 
-            _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
+            _returnFields = flat
+                .Where(x => x.IsIncludedField is true)
+                .SelectMany(x =>
+                    x.FieldTree?
+                        .Select(z => new DefaultReturnField(z)));
         }
         internal void ApplyDefaultBuckets(Cluster cluster)
         {
@@ -382,7 +386,11 @@ namespace seaq
                 .SelectMany(x =>
                     new[] { x }.Concat(x.Fields));
 
-            _returnFields = flat.Where(x => x.IsIncludedField is true).Select(x => new DefaultReturnField(x.Name));
+            _returnFields = flat
+                .Where(x => x.IsIncludedField is true)
+                .SelectMany(x =>
+                    x.FieldTree?
+                        .Select(z => new DefaultReturnField(z)));
         }
         internal void ApplyDefaultBuckets(Cluster cluster)
         {


### PR DESCRIPTION
not sold on using the fieldtree vs being more granular in child field selection, but this is a better behavior than current.  might should revisit later.